### PR TITLE
Fixes for memory bugs

### DIFF
--- a/setcifsacl.c
+++ b/setcifsacl.c
@@ -206,7 +206,7 @@ alloc_sec_desc(struct cifs_ntsd *pntsd, struct cifs_ntsd **npntsd,
 	acessize = aces * sizeof(struct cifs_ace);
 	bufsize = size + acessize;
 
-	*npntsd = malloc(bufsize);
+	*npntsd = calloc(1, bufsize);
 	if (!*npntsd) {
 		printf("%s: Memory allocation failure", __func__);
 		return errno;

--- a/setcifsacl.c
+++ b/setcifsacl.c
@@ -672,7 +672,7 @@ build_cmdline_aces(char **arrptr, int numcaces)
 			goto build_cmdline_aces_ret;
 		}
 
-		cacesptr[i] = malloc(sizeof(struct cifs_ace));
+		cacesptr[i] = calloc(1, sizeof(struct cifs_ace));
 		if (!cacesptr[i]) {
 			printf("%s: ACE alloc error %d\n", __func__, errno);
 			goto build_cmdline_aces_ret;


### PR DESCRIPTION
The changes make sure the memory is always clean (zero filled) after allocation.

The bugs were pretty hard to find, as they only occurred under certain conditions (the raw values had to be provided for "to be set" ACLs as well as the memory contents of the allocated block had to be specific).

In special cases, the code did not assign any data to some parts of the allocated memory. As a result variables referred to whatever was in the memory at the time (trash). Those values, however, were sometimes valid (although undesired) and saved later on as a file extended attribute. One could end up with valid, but completely different ACEs.

The resulting error was not very helpful either:
```
getxattr error: 95
```
Due to the unlikelihood of all factors occurring together, it make sense the bug didn't come up very often.

In this case `0`s are valid values, co `calloc` is enough, but the next step would be to always explicitly initialize ALL the variables that point to the allocated memory with valid values.